### PR TITLE
update setup instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ $ npx create-react-app client --use-npm
 If you get an error that says "We no longer support global installation of Create React App" try the following command instead:
 
 ```console
-npx create-react-app@latest my-app --use-npm
+npx create-react-app@latest client --use-npm
 ```
 
 This will create a new React application in a `client` folder, and will use npm


### PR DESCRIPTION
In the React Setup section, Line 520 has the alternate method of using "npx create-react-app@latest **_my-app_** --use-npm".

I have changed this to read "npx create-react-app@latest **_client_** --use-npm" to align with the references in the remaining portion of the setup instructions e.g. client/package.json, --prefix client, client/build, etc.